### PR TITLE
test: add pytest suite and robust screen -ls parsing

### DIFF
--- a/screenutils/screen.py
+++ b/screenutils/screen.py
@@ -5,6 +5,7 @@
 # and/or modify it under the terms of the GNU Public License 2 or upper.
 # Please ask if you wish a more permissive license.
 
+from dataclasses import dataclass
 from screenutils.errors import ScreenNotFoundError
 
 from subprocess import getoutput
@@ -12,6 +13,47 @@ from threading import Thread
 from os import system
 from os.path import getsize
 from time import sleep
+
+
+@dataclass(frozen=True)
+class ScreenInfo:
+    """Parsed information for one GNU screen session."""
+
+    id: str
+    name: str
+    status: str
+    date: str = None
+
+
+def parse_screen_ls(output):
+    """Parse ``screen -ls`` output into ``ScreenInfo`` entries."""
+    screens = []
+    for line in output.splitlines():
+        if not line.startswith("\t"):
+            continue
+
+        fields = [field for field in line.split("\t") if field]
+        if len(fields) < 2 or "." not in fields[0]:
+            continue
+
+        id_, name = fields[0].split(".", 1)
+        if not id_ or not name:
+            continue
+
+        if len(fields) >= 3:
+            date = fields[1].strip("()")
+            status = fields[2].strip("()")
+        else:
+            date = None
+            status = fields[1].strip("()")
+
+        screens.append(ScreenInfo(id=id_, name=name, date=date, status=status))
+
+    return screens
+
+
+def _get_screen_infos():
+    return parse_screen_ls(getoutput("screen -ls"))
 
 
 def tailf(file_):
@@ -33,12 +75,7 @@ def tailf(file_):
 def list_screens():
     """List all the existing screens and build a Screen instance for each
     """
-    list_cmd = "screen -ls"
-    return [
-                Screen(".".join(l.split(".")[1:]).split("\t")[0])
-                for l in getoutput(list_cmd).split('\n')
-                if "\t" in l and ".".join(l.split(".")[1:]).split("\t")[0]
-            ]
+    return [Screen(info.name) for info in _get_screen_infos()]
 
 
 class Screen(object):
@@ -81,11 +118,7 @@ class Screen(object):
     @property
     def exists(self):
         """Tell if the screen session exists or not."""
-        # Parse the screen -ls call, to find if the screen exists or not.
-        #  "	28062.G.Terminal	(Detached)"
-        lines = getoutput("screen -ls").split('\n')
-        return self.name in [".".join(l.split(".")[1:]).split("\t")[0]
-                             for l in lines if self.name in l]
+        return any(info.name == self.name for info in _get_screen_infos())
 
     def enable_logs(self, filename=None):
         if filename is None:
@@ -150,24 +183,13 @@ class Screen(object):
 
     def _set_screen_infos(self):
         """set the screen information related parameters"""
-        if self.exists:
-            line = ""
-            for l in getoutput("screen -ls").split("\n"):
-                if (
-                        l.startswith('\t') and
-                        self.name in l and
-                        self.name == ".".join(
-                            l.split('\t')[1].split('.')[1:]) in l):
-                    line = l
-            if not line:
-                raise ScreenNotFoundError("While getting info.", self.name)
-            infos = line.split('\t')[1:]
-            self._id = infos[0].split('.')[0]
-            if len(infos) == 3:
-                self._date = infos[1][1:-1]
-                self._status = infos[2][1:-1]
-            else:
-                self._status = infos[1][1:-1]
+        for info in _get_screen_infos():
+            if info.name == self.name:
+                self._id = info.id
+                self._date = info.date
+                self._status = info.status
+                return
+        raise ScreenNotFoundError("While getting info.", self.name)
 
     def _delayed_detach(self):
         sleep(0.5)

--- a/tests/test_screen_parsing.py
+++ b/tests/test_screen_parsing.py
@@ -1,0 +1,110 @@
+import pytest
+
+from screenutils.errors import ScreenNotFoundError
+from screenutils.screen import Screen, ScreenInfo, list_screens, parse_screen_ls
+
+
+NO_SCREENS = """No Sockets found in /run/screen/S-user.
+"""
+
+SINGLE_DETACHED = """There is a screen on:
+	28062.session1	(Detached)
+1 Socket in /run/screen/S-user.
+"""
+
+SINGLE_ATTACHED_WITH_DATE = """There is a screen on:
+	1234.session2	(04/24/2026 05:30:00 PM)	(Attached)
+1 Socket in /run/screen/S-user.
+"""
+
+MULTIPLE_SCREENS = """There are screens on:
+	111.foo	(Detached)
+	222.foo.bar	(Attached)
+	333.foobar	(Detached)
+3 Sockets in /run/screen/S-user.
+"""
+
+IRRELEVANT_LINES = """There are screens on:
+not a session line
+	missingdot	(Detached)
+	444.valid	(Detached)
+1 Socket in /run/screen/S-user.
+"""
+
+
+def test_parse_screen_ls_returns_empty_list_when_no_screens_exist():
+    assert parse_screen_ls(NO_SCREENS) == []
+
+
+def test_parse_screen_ls_parses_single_detached_session():
+    assert parse_screen_ls(SINGLE_DETACHED) == [
+        ScreenInfo(id="28062", name="session1", date=None, status="Detached")
+    ]
+
+
+def test_parse_screen_ls_parses_session_with_date_and_status():
+    assert parse_screen_ls(SINGLE_ATTACHED_WITH_DATE) == [
+        ScreenInfo(
+            id="1234",
+            name="session2",
+            date="04/24/2026 05:30:00 PM",
+            status="Attached",
+        )
+    ]
+
+
+def test_parse_screen_ls_preserves_dots_in_session_names():
+    assert parse_screen_ls(MULTIPLE_SCREENS)[1] == ScreenInfo(
+        id="222", name="foo.bar", date=None, status="Attached"
+    )
+
+
+def test_parse_screen_ls_ignores_irrelevant_lines():
+    assert parse_screen_ls(IRRELEVANT_LINES) == [
+        ScreenInfo(id="444", name="valid", date=None, status="Detached")
+    ]
+
+
+def test_list_screens_uses_parsed_session_names(monkeypatch):
+    monkeypatch.setattr("screenutils.screen.getoutput", lambda command: MULTIPLE_SCREENS)
+
+    screens = list_screens()
+
+    assert [screen.name for screen in screens] == ["foo", "foo.bar", "foobar"]
+    assert all(isinstance(screen, Screen) for screen in screens)
+
+
+def test_screen_exists_uses_exact_session_name_matching(monkeypatch):
+    monkeypatch.setattr("screenutils.screen.getoutput", lambda command: MULTIPLE_SCREENS)
+
+    assert Screen("foo").exists is True
+    assert Screen("foo.bar").exists is True
+    assert Screen("foobar").exists is True
+    assert Screen("fo").exists is False
+
+
+def test_screen_info_properties_use_exact_session_name_matching(monkeypatch):
+    monkeypatch.setattr("screenutils.screen.getoutput", lambda command: MULTIPLE_SCREENS)
+
+    screen = Screen("foo.bar")
+
+    assert screen.id == "222"
+    assert screen.status == "Attached"
+
+
+def test_screen_info_properties_raise_for_missing_session(monkeypatch):
+    monkeypatch.setattr("screenutils.screen.getoutput", lambda command: MULTIPLE_SCREENS)
+
+    with pytest.raises(ScreenNotFoundError):
+        Screen("missing").id
+
+
+def test_parse_screen_ls_accepts_statuses_containing_dots():
+    output = """There is a screen on:
+	555.worker	(Multi, detached)
+1 Socket in /run/screen/S-user.
+"""
+
+    assert parse_screen_ls(output) == [
+        ScreenInfo(id="555", name="worker", date=None, status="Multi, detached")
+    ]


### PR DESCRIPTION
## Summary

This PR adds robust parsing and test coverage for `screen -ls` output.

Changes included:

- Add a `ScreenInfo` dataclass for parsed GNU screen session metadata.
- Extract `screen -ls` parsing into `parse_screen_ls()`.
- Route `list_screens()`, `Screen.exists`, `Screen.id`, and `Screen.status` through the parser.
- Use exact session name matching instead of substring checks.
- Add pytest coverage for:
  - no sessions
  - detached sessions
  - attached sessions with dates
  - multiple sessions
  - names containing dots
  - names that are substrings of other names
  - irrelevant or malformed lines

## Motivation

The existing implementation parsed `screen -ls` output inline in multiple places and used substring checks for session lookup. That makes names such as `foo` and `foobar` easy to confuse and makes future command execution refactors harder to review.

This PR keeps the public API shape the same while making the parsing behavior explicit and testable.

## Validation

- `python -m pytest -q`
- `python -m build`


## Related

- #5
