### PR TITLE
fix: replace shell command construction with safe subprocess calls

### DIFF
--- a/screenutils/screen.py
+++ b/screenutils/screen.py
@@ -6,13 +6,13 @@
 # Please ask if you wish a more permissive license.
 
 from dataclasses import dataclass
-from screenutils.errors import ScreenNotFoundError
-
-from subprocess import getoutput
+from pathlib import Path
+from subprocess import PIPE, STDOUT, CalledProcessError, run
 from threading import Thread
-from os import system
 from os.path import getsize
 from time import sleep
+
+from screenutils.errors import ScreenNotFoundError
 
 
 @dataclass(frozen=True)
@@ -23,6 +23,29 @@ class ScreenInfo:
     name: str
     status: str
     date: str = None
+
+
+def _run_screen(*args, check=True):
+    """Run GNU screen with an argument list, never through a shell."""
+    return run(
+        ["screen"] + list(args),
+        stdout=PIPE,
+        stderr=STDOUT,
+        universal_newlines=True,
+        check=check,
+    )
+
+
+def _screen_output(*args):
+    """Run GNU screen and return combined stdout/stderr text.
+
+    Some screen commands, notably ``screen -ls`` when no sessions exist, may
+    return a non-zero exit code while still producing useful output.
+    """
+    try:
+        return _run_screen(*args).stdout
+    except CalledProcessError as exc:
+        return exc.output or ""
 
 
 def parse_screen_ls(output):
@@ -53,7 +76,7 @@ def parse_screen_ls(output):
 
 
 def _get_screen_infos():
-    return parse_screen_ls(getoutput("screen -ls"))
+    return parse_screen_ls(_screen_output("-ls"))
 
 
 def tailf(file_):
@@ -131,7 +154,7 @@ class Screen(object):
     def disable_logs(self, remove_logfile=False):
         self._screen_commands("log off")
         if remove_logfile:
-            system('rm ' + self._logfilename)
+            Path(self._logfilename).unlink()
         self.logs = None
 
     def initialize(self):
@@ -142,7 +165,7 @@ class Screen(object):
             Thread(target=self._delayed_detach).start()
             # support Unicode (-U),
             # attach to a new/existing named screen (-R).
-            system('screen -UR ' + self.name)
+            _run_screen("-UR", self.name)
 
     def interrupt(self):
         """Insert CTRL+C in the screen session"""
@@ -155,7 +178,7 @@ class Screen(object):
     def detach(self):
         """detach the screen"""
         self._check_exists()
-        system("screen -d " + self.id)
+        _run_screen("-d", self.id)
 
     def send_commands(self, *commands):
         """send commands to the active gnu-screen"""
@@ -173,7 +196,7 @@ class Screen(object):
         a glossary of the existing screen command in `man screen`"""
         self._check_exists()
         for command in commands:
-            system('screen -x ' + self.id + ' -X ' + command)
+            _run_screen("-x", self.id, "-X", command)
             sleep(0.02)
 
     def _check_exists(self, message="Error code: 404."):

--- a/tests/test_screen_commands.py
+++ b/tests/test_screen_commands.py
@@ -1,0 +1,96 @@
+from subprocess import CalledProcessError
+from unittest.mock import Mock
+
+import pytest
+
+from screenutils.screen import Screen, _run_screen, _screen_output
+
+
+SCREEN_LS = """There is a screen on:
+	1234.job	(Detached)
+1 Socket in /run/screen/S-user.
+"""
+
+
+def test_run_screen_uses_argument_list_without_shell(monkeypatch):
+    run_mock = Mock()
+    monkeypatch.setattr("screenutils.screen.run", run_mock)
+
+    _run_screen("-d", "1234")
+
+    run_mock.assert_called_once()
+    args, kwargs = run_mock.call_args
+    assert args[0] == ["screen", "-d", "1234"]
+    assert "shell" not in kwargs
+    assert kwargs["check"] is True
+
+
+def test_screen_output_returns_output_from_non_zero_screen_command(monkeypatch):
+    def fake_run(*args, **kwargs):
+        raise CalledProcessError(1, args[0], output="No Sockets found.\n")
+
+    monkeypatch.setattr("screenutils.screen.run", fake_run)
+
+    assert _screen_output("-ls") == "No Sockets found.\n"
+
+
+def test_initialize_runs_screen_ur_with_session_name_as_argument(monkeypatch):
+    calls = []
+    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: "No Sockets found.\n")
+    monkeypatch.setattr("screenutils.screen.Thread", lambda target: Mock(start=lambda: None))
+    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
+
+    Screen("job; rm -rf /", initialize=True)
+
+    assert calls == [("-UR", "job; rm -rf /")]
+
+
+def test_detach_runs_screen_d_with_cached_screen_id(monkeypatch):
+    calls = []
+    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
+
+    Screen("job").detach()
+
+    assert calls == [("-d", "1234")]
+
+
+def test_screen_commands_run_through_argument_list(monkeypatch):
+    calls = []
+    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
+    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: None)
+
+    Screen("job")._screen_commands("quit")
+
+    assert calls == [("-x", "1234", "-X", "quit")]
+
+
+def test_disable_logs_removes_log_file_with_pathlib(monkeypatch, tmp_path):
+    log_file = tmp_path / "screen.log"
+    log_file.write_text("hello")
+
+    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: None)
+    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: None)
+
+    screen = Screen("job")
+    screen._logfilename = str(log_file)
+    screen.disable_logs(remove_logfile=True)
+
+    assert not log_file.exists()
+
+
+def test_disable_logs_does_not_remove_log_file_by_default(monkeypatch, tmp_path):
+    log_file = tmp_path / "screen.log"
+    log_file.write_text("hello")
+
+    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: None)
+    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: None)
+
+    screen = Screen("job")
+    screen._logfilename = str(log_file)
+    screen.disable_logs()
+
+    assert log_file.exists()

--- a/tests/test_screen_parsing.py
+++ b/tests/test_screen_parsing.py
@@ -66,7 +66,7 @@ def test_parse_screen_ls_ignores_irrelevant_lines():
 
 
 def test_list_screens_uses_parsed_session_names(monkeypatch):
-    monkeypatch.setattr("screenutils.screen.getoutput", lambda command: MULTIPLE_SCREENS)
+    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: MULTIPLE_SCREENS)
 
     screens = list_screens()
 
@@ -75,7 +75,7 @@ def test_list_screens_uses_parsed_session_names(monkeypatch):
 
 
 def test_screen_exists_uses_exact_session_name_matching(monkeypatch):
-    monkeypatch.setattr("screenutils.screen.getoutput", lambda command: MULTIPLE_SCREENS)
+    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: MULTIPLE_SCREENS)
 
     assert Screen("foo").exists is True
     assert Screen("foo.bar").exists is True
@@ -84,7 +84,7 @@ def test_screen_exists_uses_exact_session_name_matching(monkeypatch):
 
 
 def test_screen_info_properties_use_exact_session_name_matching(monkeypatch):
-    monkeypatch.setattr("screenutils.screen.getoutput", lambda command: MULTIPLE_SCREENS)
+    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: MULTIPLE_SCREENS)
 
     screen = Screen("foo.bar")
 
@@ -93,7 +93,7 @@ def test_screen_info_properties_use_exact_session_name_matching(monkeypatch):
 
 
 def test_screen_info_properties_raise_for_missing_session(monkeypatch):
-    monkeypatch.setattr("screenutils.screen.getoutput", lambda command: MULTIPLE_SCREENS)
+    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: MULTIPLE_SCREENS)
 
     with pytest.raises(ScreenNotFoundError):
         Screen("missing").id


### PR DESCRIPTION
## Summary

This PR replaces shell string command construction with subprocess calls that pass GNU screen arguments as lists.

Changes included:

- Add `_run_screen()` as the internal GNU screen command runner.
- Add `_screen_output()` for commands such as `screen -ls` that may return useful output with a non-zero exit code.
- Replace `getoutput("screen -ls")` with `_screen_output("-ls")`.
- Replace `os.system("screen ...")` calls with `_run_screen(...)`.
- Replace shell-based `rm` for log cleanup with `Path.unlink()`.
- Add tests that verify command calls are made with argument lists and without `shell=True`.
- Update parsing tests to mock `_screen_output()` instead of `getoutput()`.

## Motivation

The previous implementation built shell command strings by concatenating screen IDs, session names, log file paths, and screen commands. That makes the code harder to test and exposes shell injection risks when values contain shell metacharacters.

This PR keeps the existing runtime behavior as much as possible while routing screen execution through a safer internal subprocess boundary. It intentionally does not replace interactive `screen -UR` initialization with detached `screen -dmS`; that behavior change is left for a follow-up PR.

## Validation

- `python -m pytest -q`
- `python -m build`


## Related

- #5
