### PR TITLE
fix: create sessions in detached mode without attach/detach race

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ Core Documentation
 
   - NOTE: ``.id``, ``.status``, ``.exists`` are all based off of the output of ``screen -ls``
 
-* ``screen.initialize`` Initialize a screen if does not exists yet. Equivalent to running ``screen -UR screen_name``
+* ``screen.initialize`` Initialize a detached screen if it does not exist yet. Equivalent to running ``screen -dmS screen_name``
 * ``screen.enable_logs()`` turns Screen's logging on. The Logfile's name is automatically set to that of the ``Screen`` object.
 * ``screen.logs`` A generator that acts like ``tailF`` on the logfile.
 * ``screen.disable_logs()`` turns logging off.

--- a/screenutils/screen.py
+++ b/screenutils/screen.py
@@ -8,7 +8,6 @@
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import PIPE, STDOUT, CalledProcessError, run
-from threading import Thread
 from os.path import getsize
 from time import sleep
 
@@ -158,14 +157,11 @@ class Screen(object):
         self.logs = None
 
     def initialize(self):
-        """initialize a screen, if does not exists yet"""
+        """initialize a detached screen, if does not exists yet"""
         if not self.exists:
             self._id = None
-            # Detach the screen once attached, on a new tread.
-            Thread(target=self._delayed_detach).start()
-            # support Unicode (-U),
-            # attach to a new/existing named screen (-R).
-            _run_screen("-UR", self.name)
+            # Create a new detached session without requiring a TTY.
+            _run_screen("-dmS", self.name)
 
     def interrupt(self):
         """Insert CTRL+C in the screen session"""
@@ -214,9 +210,6 @@ class Screen(object):
                 return
         raise ScreenNotFoundError("While getting info.", self.name)
 
-    def _delayed_detach(self):
-        sleep(0.5)
-        self.detach()
 
     def __repr__(self):
         return "<%s '%s'>" % (self.__class__.__name__, self.name)

--- a/tests/test_screen_commands.py
+++ b/tests/test_screen_commands.py
@@ -34,15 +34,24 @@ def test_screen_output_returns_output_from_non_zero_screen_command(monkeypatch):
     assert _screen_output("-ls") == "No Sockets found.\n"
 
 
-def test_initialize_runs_screen_ur_with_session_name_as_argument(monkeypatch):
+def test_initialize_creates_detached_session_without_tty(monkeypatch):
     calls = []
     monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: "No Sockets found.\n")
-    monkeypatch.setattr("screenutils.screen.Thread", lambda target: Mock(start=lambda: None))
     monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
 
     Screen("job; rm -rf /", initialize=True)
 
-    assert calls == [("-UR", "job; rm -rf /")]
+    assert calls == [("-dmS", "job; rm -rf /")]
+
+
+def test_initialize_does_not_create_existing_session(monkeypatch):
+    calls = []
+    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
+
+    Screen("job", initialize=True)
+
+    assert calls == []
 
 
 def test_detach_runs_screen_d_with_cached_screen_id(monkeypatch):


### PR DESCRIPTION
## Summary

This PR changes screen session initialization to create detached sessions directly.

Changes included:

- Replace interactive `screen -UR <name>` initialization with `screen -dmS <name>`.
- Remove the delayed detach thread used during initialization.
- Keep `Screen(name, initialize=True)` as the public entry point.
- Keep initialization as a no-op when the named session already exists.
- Update README documentation for `screen.initialize`.
- Update tests to verify detached session creation and no-op behavior for existing sessions.

## Motivation

The previous initialization flow attached to a screen session and relied on a background thread plus a fixed sleep to detach shortly afterwards. That approach requires interactive behavior and can race or hang in automation environments.

Creating the session directly in detached mode is simpler, deterministic, and better suited for CI, background jobs, and agent-driven automation.

## Validation

- `python -m pytest -q`
- `python -m build`


## Related

- #5
