### PR TITLE
chore: document modernization and improve log tailing

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,261 @@
+GNU GENERAL PUBLIC LICENSE
+Version 2, June 1991
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to
+share and change it.  By contrast, the GNU General Public License is intended
+to guarantee your freedom to share and change free software--to make sure the
+software is free for all its users.  This General Public License applies to
+most of the Free Software Foundation's software and to any other program whose
+authors commit to using it.  (Some other Free Software Foundation software is
+covered by the GNU Lesser General Public License instead.)  You can apply it
+to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price.  Our
+General Public Licenses are designed to make sure that you have the freedom to
+distribute copies of free software (and charge for this service if you wish),
+that you receive source code or can get it if you want it, that you can change
+the software or use pieces of it in new free programs; and that you know you
+can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny
+you these rights or to ask you to surrender the rights.  These restrictions
+translate to certain responsibilities for you if you distribute copies of the
+software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis or for
+a fee, you must give the recipients all the rights that you have.  You must
+make sure that they, too, receive or can get the source code.  And you must
+show them these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and (2)
+offer you this license which gives you legal permission to copy, distribute
+and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain that
+everyone understands that there is no warranty for this free software.  If the
+software is modified by someone else and passed on, we want its recipients to
+know that what they have is not the original, so that any problems introduced
+by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents.  We
+wish to avoid the danger that redistributors of a free program will
+individually obtain patent licenses, in effect making the program proprietary.
+To prevent this, we have made it clear that any patent must be licensed for
+everyone's free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and modification
+follow.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License applies to any program or other work which contains a notice
+placed by the copyright holder saying it may be distributed under the terms of
+this General Public License.  The "Program", below, refers to any such program
+or work, and a "work based on the Program" means either the Program or any
+derivative work under copyright law: that is to say, a work containing the
+Program or a portion of it, either verbatim or with modifications and/or
+translated into another language.  (Hereinafter, translation is included
+without limitation in the term "modification".)  Each licensee is addressed as
+"you".
+
+Activities other than copying, distribution and modification are not covered by
+this License; they are outside its scope.  The act of running the Program is
+not restricted, and the output from the Program is covered only if its contents
+constitute a work based on the Program (independent of having been made by
+running the Program).  Whether that is true depends on what the Program does.
+
+1. You may copy and distribute verbatim copies of the Program's source code as
+you receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice and
+disclaimer of warranty; keep intact all the notices that refer to this License
+and to the absence of any warranty; and give any other recipients of the
+Program a copy of this License along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and you may
+at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion of it, thus
+forming a work based on the Program, and copy and distribute such modifications
+or work under the terms of Section 1 above, provided that you also meet all of
+these conditions:
+
+    a) You must cause the modified files to carry prominent notices stating
+    that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in whole or
+    in part contains or is derived from the Program or any part thereof, to be
+    licensed as a whole at no charge to all third parties under the terms of
+    this License.
+
+    c) If the modified program normally reads commands interactively when run,
+    you must cause it, when started running for such interactive use in the
+    most ordinary way, to print or display an announcement including an
+    appropriate copyright notice and a notice that there is no warranty (or
+    else, saying that you provide a warranty) and that users may redistribute
+    the program under these conditions, and telling the user how to view a copy
+    of this License.  (Exception: if the Program itself is interactive but does
+    not normally print such an announcement, your work based on the Program is
+    not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If identifiable
+sections of that work are not derived from the Program, and can be reasonably
+considered independent and separate works in themselves, then this License, and
+its terms, do not apply to those sections when you distribute them as separate
+works.  But when you distribute the same sections as part of a whole which is a
+work based on the Program, the distribution of the whole must be on the terms
+of this License, whose permissions for other licensees extend to the entire
+whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your
+rights to work written entirely by you; rather, the intent is to exercise the
+right to control the distribution of derivative or collective works based on
+the Program.
+
+In addition, mere aggregation of another work not based on the Program with the
+Program (or with a work based on the Program) on a volume of a storage or
+distribution medium does not bring the other work under the scope of this
+License.
+
+3. You may copy and distribute the Program (or a work based on it, under
+Section 2) in object code or executable form under the terms of Sections 1 and
+2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable source
+    code, which must be distributed under the terms of Sections 1 and 2 above
+    on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three years, to
+    give any third party, for a charge no more than your cost of physically
+    performing source distribution, a complete machine-readable copy of the
+    corresponding source code, to be distributed under the terms of Sections 1
+    and 2 above on a medium customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer to
+    distribute corresponding source code.  (This alternative is allowed only
+    for noncommercial distribution and only if you received the program in
+    object code or executable form with such an offer, in accord with
+    Subsection b above.)
+
+The source code for a work means the preferred form of the work for making
+modifications to it.  For an executable work, complete source code means all
+the source code for all modules it contains, plus any associated interface
+definition files, plus the scripts used to control compilation and installation
+of the executable.  However, as a special exception, the source code
+distributed need not include anything that is normally distributed (in either
+source or binary form) with the major components (compiler, kernel, and so on)
+of the operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the source
+code from the same place counts as distribution of the source code, even though
+third parties are not compelled to copy the source along with the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program except as
+expressly provided under this License.  Any attempt otherwise to copy, modify,
+sublicense or distribute the Program is void, and will automatically terminate
+your rights under this License.  However, parties who have received copies, or
+rights, from you under this License will not have their licenses terminated so
+long as such parties remain in full compliance.
+
+5. You are not required to accept this License, since you have not signed it.
+However, nothing else grants you permission to modify or distribute the Program
+or its derivative works.  These actions are prohibited by law if you do not
+accept this License.  Therefore, by modifying or distributing the Program (or
+any work based on the Program), you indicate your acceptance of this License to
+do so, and all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the Program),
+the recipient automatically receives a license from the original licensor to
+copy, distribute or modify the Program subject to these terms and conditions.
+You may not impose any further restrictions on the recipients' exercise of the
+rights granted herein.  You are not responsible for enforcing compliance by
+third parties to this License.
+
+7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues), conditions
+are imposed on you (whether by court order, agreement or otherwise) that
+contradict the conditions of this License, they do not excuse you from the
+conditions of this License.  If you cannot distribute so as to satisfy
+simultaneously your obligations under this License and any other pertinent
+obligations, then as a consequence you may not distribute the Program at all.
+For example, if a patent license would not permit royalty-free redistribution
+of the Program by all those who receive copies directly or indirectly through
+you, then the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply and
+the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or
+other property right claims or to contest validity of any such claims; this
+section has the sole purpose of protecting the integrity of the free software
+distribution system, which is implemented by public license practices.  Many
+people have made generous contributions to the wide range of software
+distributed through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing to
+distribute software through any other system and a licensee cannot impose that
+choice.
+
+This section is intended to make thoroughly clear what is believed to be a
+consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in certain
+countries either by patents or by copyrighted interfaces, the original
+copyright holder who places the Program under this License may add an explicit
+geographical distribution limitation excluding those countries, so that
+distribution is permitted only in or among countries not thus excluded.  In
+such case, this License incorporates the limitation as if written in the body
+of this License.
+
+9. The Free Software Foundation may publish revised and/or new versions of the
+General Public License from time to time.  Such new versions will be similar in
+spirit to the present version, but may differ in detail to address new problems
+or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any later
+version", you have the option of following the terms and conditions either of
+that version or of any later version published by the Free Software Foundation.
+If the Program does not specify a version number of this License, you may
+choose any version ever published by the Free Software Foundation.
+
+10. If you wish to incorporate parts of the Program into other free programs
+whose distribution conditions are different, write to the author to ask for
+permission.  For software which is copyrighted by the Free Software Foundation,
+write to the Free Software Foundation; we sometimes make exceptions for this.
+Our decision will be guided by the two goals of preserving the free status of
+all derivatives of our free software and of promoting the sharing and reuse of
+software generally.
+
+NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR
+THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN OTHERWISE
+STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE
+PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND
+PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE,
+YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL
+ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR
+INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR
+DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR
+A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH
+HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS

--- a/docs/modernization-plan.md
+++ b/docs/modernization-plan.md
@@ -1,0 +1,510 @@
+# screenutils Modernization Plan
+
+This document describes a staged modernization plan for `screenutils`, a small Python wrapper around GNU screen. The goal is to make the project safe, testable, Python 3 native, and suitable for automation use cases while preserving the spirit of the original API where practical.
+
+## 1. Project Assessment
+
+`screenutils` currently provides a thin Python interface for:
+
+- Listing GNU screen sessions.
+- Creating named screen sessions.
+- Sending commands or control sequences into a session.
+- Enabling and reading screen logs.
+- Detaching or quitting sessions.
+- Granting multi-user screen access.
+
+The codebase is intentionally small, but it reflects older Python and shell scripting practices. The most important current limitations are:
+
+- Python 2 compatibility code is still present.
+- Packaging uses `distutils` through `setup.py`.
+- There is no automated test suite.
+- Shell commands are built through string concatenation and executed through `os.system`.
+- `screen -ls` output parsing is fragile.
+- Session creation uses interactive `screen -UR` plus a delayed detach thread.
+- Logging is implemented with a polling generator that can spin too aggressively.
+- The public API lacks type hints and modern convenience methods.
+- Documentation still contains Python 2 style examples.
+- The `LICENCE` file is empty even though the package metadata and source headers refer to GPLv2+.
+
+## 2. Modernization Goals
+
+The modernization should pursue the following goals:
+
+1. Make the project Python 3 native.
+2. Replace unsafe shell command construction with safe subprocess calls.
+3. Make GNU screen session parsing robust and testable.
+4. Make session creation deterministic and non-interactive.
+5. Improve log handling for automation workloads.
+6. Preserve backward-compatible API entry points where reasonable.
+7. Add tests, CI, and clear release metadata.
+8. Clarify project maintenance status, licensing, and supported platforms.
+
+Non-goals for the initial modernization:
+
+- Replacing GNU screen with tmux.
+- Implementing a full terminal emulator.
+- Supporting every advanced GNU screen feature.
+- Maintaining Python 2 compatibility.
+
+## 3. Proposed Pull Request Plan
+
+The work should be split into small, reviewable pull requests. Each PR should have a clear scope and should leave the project in a working state.
+
+### PR 1: chore: Modernize Packaging and Drop Python 2 Compatibility
+
+Suggested title:
+
+```text
+chore: modernize packaging and drop Python 2 compatibility
+```
+
+Purpose:
+
+Establish a modern Python 3 project baseline before deeper refactoring begins.
+
+Scope:
+
+- Add `pyproject.toml` with modern project metadata.
+- Declare the supported Python version range, for example `>=3.8` or `>=3.9`.
+- Remove Python 2 compatibility imports such as `commands.getoutput`.
+- Replace old Python 2 examples in the README.
+- Keep `setup.py` only if needed as a compatibility shim, or remove it if the packaging backend supports the desired workflow.
+- Add a minimal GitHub Actions CI workflow for install and test commands.
+- Add basic development dependencies, such as `pytest` and optionally a linter.
+
+Suggested implementation details:
+
+- Use `setuptools` as the initial backend to minimize migration risk.
+- Keep package name and import paths unchanged.
+- Do not refactor runtime behavior in this PR except what is required for Python 3 only cleanup.
+
+Acceptance criteria:
+
+- The package can be installed locally with `pip install -e .`.
+- `python -m build` works if a build backend is configured.
+- The existing public imports still work:
+
+  ```python
+  from screenutils import Screen, list_screens, ScreenNotFoundError
+  ```
+
+- CI runs successfully.
+- README examples use Python 3 syntax.
+
+Risk level: low.
+
+Priority: highest. This PR creates the foundation for all later work.
+
+### PR 2: test: Add Tests and Robust `screen -ls` Parsing
+
+Suggested title:
+
+```text
+test: add pytest suite and robust screen -ls parsing
+```
+
+Purpose:
+
+Make the most fragile part of the project testable before replacing command execution internals.
+
+Scope:
+
+- Add a pytest test suite.
+- Extract `screen -ls` parsing into a pure function.
+- Introduce an internal representation for parsed sessions, for example:
+
+  ```python
+  @dataclass(frozen=True)
+  class ScreenInfo:
+      pid: str
+      name: str
+      status: str | None = None
+      date: str | None = None
+  ```
+
+- Add tests for typical and edge-case `screen -ls` outputs.
+- Update `list_screens()`, `Screen.exists`, `Screen.id`, and `Screen.status` to use the parser.
+
+Test cases should cover:
+
+- No active screen sessions.
+- One detached session.
+- One attached session.
+- Multiple sessions.
+- Session names containing dots.
+- Session names that are substrings of other names, such as `foo` and `foobar`.
+- Unexpected or irrelevant lines in `screen -ls` output.
+
+Acceptance criteria:
+
+- Parser behavior is covered by unit tests.
+- `list_screens()` returns the same high-level type as before: a list of `Screen` objects.
+- Existing public properties continue to work.
+- Session name matching is exact, not substring-based.
+
+Risk level: low to medium.
+
+Priority: high.
+
+### PR 3: fix: Replace Shell Command Construction with Safe Subprocess Calls
+
+Suggested title:
+
+```text
+fix: replace shell command construction with safe subprocess calls
+```
+
+Purpose:
+
+Remove shell injection risks and make command execution behavior easier to test.
+
+Current risky patterns include:
+
+```python
+system('screen -UR ' + self.name)
+system('screen -x ' + self.id + ' -X ' + command)
+system('rm ' + self._logfilename)
+getoutput('screen -ls')
+```
+
+Scope:
+
+- Replace `os.system` with `subprocess.run([...], check=True)`.
+- Replace `subprocess.getoutput("screen -ls")` with explicit subprocess calls using argument lists.
+- Use `pathlib.Path` for log file deletion instead of shelling out to `rm`.
+- Add an internal command runner abstraction if helpful for testing.
+- Validate screen session names and reject unsafe or empty names.
+- Review quoting and escaping around GNU screen `stuff` commands.
+
+Potential internal helper:
+
+```python
+def run_screen_command(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["screen", *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+```
+
+Acceptance criteria:
+
+- No runtime path uses `os.system`.
+- No runtime path uses shell command strings for subprocess execution.
+- Log file removal does not call `rm`.
+- Unit tests cover command construction through mocks.
+- Existing public methods still exist.
+
+Risk level: medium.
+
+Priority: very high. This is the most important security-oriented change.
+
+### PR 4: fix: Create Sessions in Detached Mode Without Attach/Detach Race
+
+Suggested title:
+
+```text
+fix: create sessions in detached mode without attach/detach race
+```
+
+Purpose:
+
+Make session initialization deterministic and suitable for non-interactive automation environments.
+
+Current behavior:
+
+```python
+Thread(target=self._delayed_detach).start()
+system('screen -UR ' + self.name)
+```
+
+This approach relies on an interactive attach, a background thread, and a fixed sleep interval.
+
+Scope:
+
+- Replace interactive initialization with detached session creation:
+
+  ```bash
+  screen -dmS <name>
+  ```
+
+- Remove `_delayed_detach()` and the thread-based detach mechanism.
+- Keep `Screen(name, initialize=True)` as a compatibility entry point.
+- Make initialization a no-op when the session already exists.
+- Document behavior clearly.
+
+Acceptance criteria:
+
+- `Screen("name", initialize=True)` creates a detached screen session.
+- Initialization does not require a TTY.
+- No thread is created for detach behavior.
+- Existing `detach()` remains available for manually detaching attached sessions.
+
+Risk level: medium.
+
+Priority: high.
+
+### PR 5: fix: Improve Logging and Tail Support
+
+Suggested title:
+
+```text
+fix: improve logging and tail support
+```
+
+Purpose:
+
+Make log handling reliable enough for automation workflows.
+
+Scope:
+
+- Improve `tailf()` to avoid busy-spinning.
+- Add configurable polling interval.
+- Handle file truncation and missing files more gracefully.
+- Add explicit encoding and error handling.
+- Consider adding a higher-level method such as:
+
+  ```python
+  def tail_logs(self, timeout: float | None = None, interval: float = 0.1):
+      ...
+  ```
+
+- Keep `screen.logs` compatibility if possible.
+- Ensure `disable_logs(remove_logfile=True)` uses `Path.unlink()`.
+
+Acceptance criteria:
+
+- Tail logic does not spin in a tight loop.
+- Log reading supports Python 3 text handling.
+- Log cleanup is safe.
+- Unit tests cover truncation and incremental reading.
+
+Risk level: low to medium.
+
+Priority: medium-high.
+
+### PR 6: feat: Add a Modern High-Level API with Type Hints
+
+Suggested title:
+
+```text
+feat: add high-level Python 3 API with type hints
+```
+
+Purpose:
+
+Improve developer ergonomics while preserving the original API where possible.
+
+Possible new API surface:
+
+```python
+from screenutils import Screen
+
+s = Screen.ensure("job")
+s.send_line("python train.py")
+s.ctrl_c()
+s.quit()
+```
+
+Potential additions:
+
+- `Screen.create(name)`
+- `Screen.ensure(name)`
+- `Screen.get(name)`
+- `send_text(text)`
+- `send_line(command)`
+- `ctrl_c()` as a clearer alias for `interrupt()`
+- `quit()` as a clearer alias for `kill()`
+- Context manager support if semantics are clear.
+- Type hints across the public API.
+
+Compatibility guidance:
+
+- Keep `send_commands(*commands)` as an alias or wrapper.
+- Keep `interrupt()` and `kill()` unless there is a major-version release.
+- Avoid surprising automatic cleanup in `__exit__` unless explicitly documented.
+
+Acceptance criteria:
+
+- New API is documented and tested.
+- Existing API continues to work.
+- Type hints are present for public methods.
+
+Risk level: low to medium.
+
+Priority: medium.
+
+### PR 7: test: Add Optional GNU screen Integration Tests
+
+Suggested title:
+
+```text
+test: add optional GNU screen integration tests
+```
+
+Purpose:
+
+Verify that the wrapper actually works against a real GNU screen binary.
+
+Scope:
+
+- Add pytest markers for integration tests.
+- Skip integration tests automatically when `screen` is unavailable.
+- Test the lifecycle:
+  - create session
+  - list session
+  - send command
+  - enable logs
+  - read expected output
+  - interrupt if needed
+  - quit session
+- Ensure cleanup runs even on failure.
+
+Acceptance criteria:
+
+- Integration tests can be run locally with a documented command.
+- Tests are skipped cleanly when GNU screen is not installed.
+- CI either runs them in an environment with screen installed or keeps them optional.
+
+Risk level: medium due to environment variability.
+
+Priority: medium.
+
+### PR 8: docs: Refresh Documentation, License, and Release Workflow
+
+Suggested title:
+
+```text
+docs: refresh documentation, license, and release workflow
+```
+
+Purpose:
+
+Make the project understandable and releasable after modernization.
+
+Scope:
+
+- Rewrite README for Python 3 users.
+- Add examples for common automation workflows.
+- Document GNU screen as a system dependency.
+- Document security constraints and session name validation.
+- Add or fix license text.
+- Add `CHANGELOG.md`.
+- Add `CONTRIBUTING.md` if future external contributions are expected.
+- Add build and release workflow if publishing is planned.
+
+License note:
+
+The source headers and setup metadata refer to GPLv2 or later, but the current `LICENCE` file is empty. This should be corrected before publishing new releases.
+
+Acceptance criteria:
+
+- README accurately reflects the modern API.
+- License file is no longer empty.
+- Release steps are documented.
+
+Risk level: low.
+
+Priority: medium-low, but important before public release.
+
+## 4. Recommended Execution Strategy
+
+### Minimal Maintainable Version
+
+Implement PRs 1 through 4:
+
+1. Modern packaging and Python 3 baseline.
+2. Tests and parser extraction.
+3. Safe subprocess command execution.
+4. Non-interactive detached session creation.
+
+This makes the project maintainable and much safer without expanding scope too far.
+
+### Practical Automation Version
+
+Implement PRs 1 through 6:
+
+1. Modern packaging.
+2. Parser tests.
+3. Safe subprocess execution.
+4. Detached initialization.
+5. Better logging.
+6. Modern high-level API.
+
+This makes the library practical for automation tools, background jobs, and agent workflows.
+
+### Full Revival Version
+
+Implement all 8 PRs:
+
+1. Modern packaging.
+2. Parser tests.
+3. Safe subprocess execution.
+4. Detached initialization.
+5. Better logging.
+6. Modern high-level API.
+7. Integration tests.
+8. Documentation, license, and release workflow.
+
+This is the right path if the project will be republished or maintained as an active fork.
+
+## 5. Backward Compatibility Policy
+
+Recommended policy:
+
+- Keep existing import paths stable.
+- Keep existing method names for at least one modernization release.
+- Add clearer aliases instead of immediately removing old names.
+- Document changed behavior around initialization, especially replacing interactive `screen -UR` with detached creation.
+- If behavior changes are substantial, release as a new minor or major version depending on project versioning policy.
+
+Potential compatibility aliases:
+
+- `send_commands()` remains available and delegates to `send_line()`.
+- `interrupt()` remains available and delegates to `ctrl_c()`.
+- `kill()` remains available and delegates to `quit()`.
+
+## 6. Security Considerations
+
+The most important security requirement is to avoid shell execution with user-controlled strings.
+
+The following values should be treated as untrusted input:
+
+- Screen session names.
+- Commands sent to a session.
+- Log file paths.
+- Unix user names passed to ACL-related methods.
+
+Recommended safeguards:
+
+- Use `subprocess.run()` with argument lists and `shell=False`.
+- Validate session names.
+- Use `pathlib.Path` for filesystem operations.
+- Avoid implementing shell escaping manually unless GNU screen itself requires a specific syntax.
+- Add tests for names and commands containing spaces or special characters.
+
+## 7. Open Questions
+
+Before starting implementation, decide:
+
+1. What minimum Python version should be supported?
+2. Should this fork keep the package name `screenutils`, or use a new name if republished?
+3. Should `Screen.kill()` remain the preferred method, or should `quit()` become primary?
+4. Should multi-user ACL support remain, given the system-level permission implications?
+5. Should the project maintain GPLv2+ licensing, or only clarify the existing license file?
+6. Should integration tests run in CI by default, or only locally/on demand?
+
+## 8. Suggested PR 1 Checklist
+
+For the immediate next step, PR 1 should include:
+
+- [ ] Add `pyproject.toml`.
+- [ ] Declare Python 3 support only.
+- [ ] Remove Python 2-only import fallback.
+- [ ] Update README examples to Python 3 syntax.
+- [ ] Add a minimal pytest setup.
+- [ ] Add GitHub Actions CI.
+- [ ] Confirm `pip install -e .` works.
+- [ ] Confirm public imports still work.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,9 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "http://github.com/Christophe31/screenutils"
-Repository = "http://github.com/Christophe31/screenutils"
+Homepage = "https://github.com/TutuchanXD/screenutils"
+Repository = "https://github.com/TutuchanXD/screenutils"
+"Upstream Repository" = "https://github.com/Christophe31/screenutils"
 
 [tool.setuptools.packages.find]
 include = ["screenutils*"]

--- a/screenutils/screen.py
+++ b/screenutils/screen.py
@@ -8,7 +8,6 @@
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import PIPE, STDOUT, CalledProcessError, run
-from os.path import getsize
 from time import sleep
 
 from screenutils.errors import ScreenNotFoundError
@@ -78,19 +77,26 @@ def _get_screen_infos():
     return parse_screen_ls(_screen_output("-ls"))
 
 
-def tailf(file_):
-    """Each value is content added to the log file since last value return"""
-    last_size = getsize(file_)
+def tailf(file_, interval=0.1):
+    """Yield content appended to a log file, similar to ``tail -f``.
+
+    The generator preserves the historical behavior of yielding an empty
+    string when no new content is available, but it now sleeps briefly between
+    empty reads to avoid a busy loop in automation code.
+    """
+    path = Path(file_)
+    last_size = path.stat().st_size
     while True:
-        cur_size = getsize(file_)
-        if (cur_size != last_size):
-            f = open(file_, 'r')
-            f.seek(last_size if cur_size > last_size else 0)
-            text = f.read()
-            f.close()
+        cur_size = path.stat().st_size
+        if cur_size != last_size:
+            with path.open("r") as f:
+                f.seek(last_size if cur_size > last_size else 0)
+                text = f.read()
             last_size = cur_size
             yield text
         else:
+            if interval:
+                sleep(interval)
             yield ""
 
 
@@ -147,7 +153,7 @@ class Screen(object):
             filename = self.name
         self._screen_commands("logfile " + filename, "log on")
         self._logfilename = filename
-        open(filename, 'w+')
+        Path(filename).touch()
         self.logs = tailf(filename)
 
     def disable_logs(self, remove_logfile=False):

--- a/tests/test_tailf.py
+++ b/tests/test_tailf.py
@@ -1,0 +1,18 @@
+from screenutils.screen import tailf
+
+
+def test_tailf_yields_appended_text_without_busy_wait(monkeypatch, tmp_path):
+    sleeps = []
+    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: sleeps.append(seconds))
+
+    log_file = tmp_path / "screen.log"
+    log_file.write_text("initial")
+
+    logs = tailf(log_file, interval=0.25)
+
+    assert next(logs) == ""
+    assert sleeps == [0.25]
+
+    log_file.write_text("initial\nnext")
+
+    assert next(logs) == "\nnext"


### PR DESCRIPTION
## Summary

- add the modernization plan document to version control
- fill in the GPLv2 license text and update project repository links for this maintained fork
- make tailf sleep briefly on empty reads to avoid busy loops while preserving the existing empty-string yield behavior
- add coverage for appended log reads and idle waits

## Tests

- .venv/bin/python -m pytest -q