### PR TITLE
fix: improve log tail robustness

### DIFF
--- a/screenutils/screen.py
+++ b/screenutils/screen.py
@@ -8,7 +8,7 @@
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import PIPE, STDOUT, CalledProcessError, run
-from time import sleep
+from time import monotonic, sleep
 
 from screenutils.errors import ScreenNotFoundError
 
@@ -77,19 +77,31 @@ def _get_screen_infos():
     return parse_screen_ls(_screen_output("-ls"))
 
 
-def tailf(file_, interval=0.1):
+def tailf(file_, interval=0.1, encoding="utf-8", errors="replace", missing_ok=False):
     """Yield content appended to a log file, similar to ``tail -f``.
 
     The generator preserves the historical behavior of yielding an empty
     string when no new content is available, but it now sleeps briefly between
     empty reads to avoid a busy loop in automation code.
+
+    If ``missing_ok`` is true, missing files are treated like idle reads until
+    the file appears. Otherwise, a missing initial file raises
+    ``FileNotFoundError``.
     """
     path = Path(file_)
-    last_size = path.stat().st_size
+    last_size = 0 if missing_ok and not path.exists() else path.stat().st_size
     while True:
+        if not path.exists():
+            if not missing_ok:
+                raise FileNotFoundError(path)
+            if interval:
+                sleep(interval)
+            yield ""
+            continue
+
         cur_size = path.stat().st_size
         if cur_size != last_size:
-            with path.open("r") as f:
+            with path.open("r", encoding=encoding, errors=errors) as f:
                 f.seek(last_size if cur_size > last_size else 0)
                 text = f.read()
             last_size = cur_size
@@ -148,13 +160,30 @@ class Screen(object):
         """Tell if the screen session exists or not."""
         return any(info.name == self.name for info in _get_screen_infos())
 
-    def enable_logs(self, filename=None):
+    def enable_logs(self, filename=None, interval=0.1, encoding="utf-8", errors="replace"):
         if filename is None:
             filename = self.name
         self._screen_commands("logfile " + filename, "log on")
         self._logfilename = filename
         Path(filename).touch()
-        self.logs = tailf(filename)
+        self.logs = self.tail_logs(interval=interval, encoding=encoding, errors=errors)
+
+    def tail_logs(self, timeout=None, interval=0.1, encoding="utf-8", errors="replace"):
+        """Yield log chunks until ``timeout`` seconds elapse, if provided."""
+        if self._logfilename is None:
+            raise RuntimeError("Logs are not enabled. Call enable_logs() first.")
+
+        deadline = None if timeout is None else monotonic() + timeout
+        for chunk in tailf(
+            self._logfilename,
+            interval=interval,
+            encoding=encoding,
+            errors=errors,
+            missing_ok=True,
+        ):
+            if deadline is not None and monotonic() >= deadline:
+                return
+            yield chunk
 
     def disable_logs(self, remove_logfile=False):
         self._screen_commands("log off")

--- a/tests/test_tailf.py
+++ b/tests/test_tailf.py
@@ -1,4 +1,12 @@
-from screenutils.screen import tailf
+import pytest
+
+from screenutils.screen import Screen, tailf
+
+
+SCREEN_LS = """There is a screen on:
+\t1234.job\t(Detached)
+1 Socket in /run/screen/S-user.
+"""
 
 
 def test_tailf_yields_appended_text_without_busy_wait(monkeypatch, tmp_path):
@@ -16,3 +24,93 @@ def test_tailf_yields_appended_text_without_busy_wait(monkeypatch, tmp_path):
     log_file.write_text("initial\nnext")
 
     assert next(logs) == "\nnext"
+
+
+def test_tailf_reads_from_start_after_truncation(tmp_path):
+    log_file = tmp_path / "screen.log"
+    log_file.write_text("initial content")
+
+    logs = tailf(log_file, interval=0)
+
+    assert next(logs) == ""
+
+    log_file.write_text("new")
+
+    assert next(logs) == "new"
+
+
+def test_tailf_missing_initial_file_raises_by_default(tmp_path):
+    log_file = tmp_path / "missing.log"
+
+    with pytest.raises(FileNotFoundError):
+        next(tailf(log_file))
+
+
+def test_tailf_can_wait_for_missing_file(monkeypatch, tmp_path):
+    sleeps = []
+    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: sleeps.append(seconds))
+
+    log_file = tmp_path / "missing.log"
+    logs = tailf(log_file, interval=0.5, missing_ok=True)
+
+    assert next(logs) == ""
+    assert sleeps == [0.5]
+
+    log_file.write_text("created")
+
+    assert next(logs) == "created"
+
+
+def test_tailf_replaces_invalid_bytes_when_configured(tmp_path):
+    log_file = tmp_path / "screen.log"
+    log_file.write_bytes(b"initial")
+
+    logs = tailf(log_file, interval=0, encoding="utf-8", errors="replace")
+
+    assert next(logs) == ""
+
+    log_file.write_bytes(b"initial\xff")
+
+    assert next(logs) == "\ufffd"
+
+
+def test_tail_logs_requires_logs_to_be_enabled():
+    screen = Screen("job")
+
+    with pytest.raises(RuntimeError, match="Logs are not enabled"):
+        next(screen.tail_logs())
+
+
+def test_enable_logs_configures_tail_logs(monkeypatch, tmp_path):
+    log_file = tmp_path / "screen.log"
+
+    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: None)
+    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: None)
+
+    screen = Screen("job")
+    screen.enable_logs(str(log_file), interval=0)
+
+    assert next(screen.logs) == ""
+
+    log_file.write_text("hello")
+
+    assert next(screen.logs) == "hello"
+
+
+def test_tail_logs_stops_after_timeout(monkeypatch, tmp_path):
+    times = iter([0.0, 0.05, 0.2])
+    monkeypatch.setattr("screenutils.screen.monotonic", lambda: next(times))
+    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: None)
+
+    log_file = tmp_path / "screen.log"
+    log_file.write_text("")
+
+    screen = Screen("job")
+    screen._logfilename = str(log_file)
+
+    logs = screen.tail_logs(timeout=0.1, interval=0)
+
+    assert next(logs) == ""
+    with pytest.raises(StopIteration):
+        next(logs)


### PR DESCRIPTION
## Summary

- extend tailf with encoding/errors options and optional missing-file tolerance
- handle truncation by reading from the beginning after file size shrinks
- add Screen.tail_logs() with optional timeout while keeping screen.logs compatibility
- expand log tail unit coverage for idle polling, truncation, missing files, encoding errors, enable_logs(), and timeout behavior

Closes #11.

## Tests

- .venv/bin/python -m pytest -q