### PR TITLE
test: add optional GNU screen integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,6 @@ include = ["screenutils*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "integration: tests that require a real GNU screen binary",
+]

--- a/screenutils/screen.py
+++ b/screenutils/screen.py
@@ -7,7 +7,8 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from subprocess import PIPE, STDOUT, CalledProcessError, CompletedProcess, run
+from tempfile import NamedTemporaryFile
+from subprocess import DEVNULL, PIPE, STDOUT, CalledProcessError, CompletedProcess, run
 from time import monotonic, sleep
 from typing import Generator, List, Optional, Union
 
@@ -261,12 +262,23 @@ class Screen(object):
     def send_text(self, text: str) -> None:
         """Send raw text to the active GNU screen session."""
         self._check_exists()
-        self._screen_commands('stuff "' + text + '" ')
+        _run_screen("-S", self.id, "-X", "stuff", text)
 
     def send_line(self, command: str) -> None:
         """Send one command line to the active GNU screen session."""
-        self.send_text(command)
-        self._screen_commands('eval "stuff \\015"')
+        self.send_text(command + "\n")
+
+    def hardcopy(self) -> str:
+        """Return the current visible contents of the screen session."""
+        self._check_exists()
+        with NamedTemporaryFile() as hardcopy_file:
+            run(
+                ["screen", "-S", self.id, "-X", "hardcopy", "-h", hardcopy_file.name],
+                stdout=DEVNULL,
+                stderr=DEVNULL,
+                check=True,
+            )
+            return Path(hardcopy_file.name).read_text(errors="replace")
 
     def send_commands(self, *commands: str) -> None:
         """send commands to the active gnu-screen"""

--- a/screenutils/screen.py
+++ b/screenutils/screen.py
@@ -8,7 +8,7 @@
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from subprocess import DEVNULL, PIPE, STDOUT, CalledProcessError, CompletedProcess, run
+from subprocess import PIPE, STDOUT, CalledProcessError, CompletedProcess, run
 from time import monotonic, sleep
 from typing import Generator, List, Optional, Union
 
@@ -263,6 +263,7 @@ class Screen(object):
         """Send raw text to the active GNU screen session."""
         self._check_exists()
         _run_screen("-S", self.id, "-X", "stuff", text)
+        sleep(0.02)
 
     def send_line(self, command: str) -> None:
         """Send one command line to the active GNU screen session."""
@@ -272,12 +273,7 @@ class Screen(object):
         """Return the current visible contents of the screen session."""
         self._check_exists()
         with NamedTemporaryFile() as hardcopy_file:
-            run(
-                ["screen", "-S", self.id, "-X", "hardcopy", "-h", hardcopy_file.name],
-                stdout=DEVNULL,
-                stderr=DEVNULL,
-                check=True,
-            )
+            _run_screen("-S", self.id, "-X", "hardcopy", "-h", hardcopy_file.name)
             return Path(hardcopy_file.name).read_text(errors="replace")
 
     def send_commands(self, *commands: str) -> None:

--- a/tests/test_high_level_api.py
+++ b/tests/test_high_level_api.py
@@ -54,31 +54,36 @@ def test_get_raises_for_missing_screen(monkeypatch):
 
 def test_send_text_sends_without_enter(monkeypatch):
     calls = []
+    sleeps = []
     monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
     monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
-    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: None)
+    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: sleeps.append(seconds))
 
     Screen("job").send_text("hello")
 
     assert calls == [("-S", "1234", "-X", "stuff", "hello")]
+    assert sleeps == [0.02]
 
 
 def test_send_line_sends_text_and_enter(monkeypatch):
     calls = []
+    sleeps = []
     monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
     monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
-    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: None)
+    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: sleeps.append(seconds))
 
     Screen("job").send_line("echo hello")
 
     assert calls == [("-S", "1234", "-X", "stuff", "echo hello\n")]
+    assert sleeps == [0.02]
 
 
 def test_legacy_send_commands_delegates_to_send_line(monkeypatch):
     calls = []
+    sleeps = []
     monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
     monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
-    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: None)
+    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: sleeps.append(seconds))
 
     Screen("job").send_commands("one", "two")
 
@@ -86,6 +91,32 @@ def test_legacy_send_commands_delegates_to_send_line(monkeypatch):
         ("-S", "1234", "-X", "stuff", "one\n"),
         ("-S", "1234", "-X", "stuff", "two\n"),
     ]
+    assert sleeps == [0.02, 0.02]
+
+
+def test_hardcopy_uses_screen_runner_and_returns_file_text(monkeypatch, tmp_path):
+    calls = []
+    hardcopy_path = tmp_path / "hardcopy.txt"
+
+    class FakeTemporaryFile:
+        name = str(hardcopy_path)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    def fake_run_screen(*args):
+        calls.append(args)
+        hardcopy_path.write_text("visible text", encoding="utf-8")
+
+    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenutils.screen.NamedTemporaryFile", FakeTemporaryFile)
+    monkeypatch.setattr("screenutils.screen._run_screen", fake_run_screen)
+
+    assert Screen("job").hardcopy() == "visible text"
+    assert calls == [("-S", "1234", "-X", "hardcopy", "-h", str(hardcopy_path))]
 
 
 def test_ctrl_c_and_quit_aliases(monkeypatch):

--- a/tests/test_high_level_api.py
+++ b/tests/test_high_level_api.py
@@ -60,7 +60,7 @@ def test_send_text_sends_without_enter(monkeypatch):
 
     Screen("job").send_text("hello")
 
-    assert calls == [("-x", "1234", "-X", 'stuff "hello" ')]
+    assert calls == [("-S", "1234", "-X", "stuff", "hello")]
 
 
 def test_send_line_sends_text_and_enter(monkeypatch):
@@ -71,10 +71,7 @@ def test_send_line_sends_text_and_enter(monkeypatch):
 
     Screen("job").send_line("echo hello")
 
-    assert calls == [
-        ("-x", "1234", "-X", 'stuff "echo hello" '),
-        ("-x", "1234", "-X", 'eval "stuff \\015"'),
-    ]
+    assert calls == [("-S", "1234", "-X", "stuff", "echo hello\n")]
 
 
 def test_legacy_send_commands_delegates_to_send_line(monkeypatch):
@@ -86,10 +83,8 @@ def test_legacy_send_commands_delegates_to_send_line(monkeypatch):
     Screen("job").send_commands("one", "two")
 
     assert calls == [
-        ("-x", "1234", "-X", 'stuff "one" '),
-        ("-x", "1234", "-X", 'eval "stuff \\015"'),
-        ("-x", "1234", "-X", 'stuff "two" '),
-        ("-x", "1234", "-X", 'eval "stuff \\015"'),
+        ("-S", "1234", "-X", "stuff", "one\n"),
+        ("-S", "1234", "-X", "stuff", "two\n"),
     ]
 
 

--- a/tests/test_integration_screen.py
+++ b/tests/test_integration_screen.py
@@ -1,0 +1,63 @@
+import shutil
+import time
+from uuid import uuid4
+
+import pytest
+
+from screenutils import Screen, list_screens
+
+
+pytestmark = pytest.mark.integration
+
+
+def _screen_available():
+    return shutil.which("screen") is not None
+
+
+@pytest.fixture
+def screen_session():
+    if not _screen_available():
+        pytest.skip("GNU screen binary is not installed")
+
+    name = f"screenutils-it-{uuid4().hex}"
+    screen = Screen.create(name)
+    try:
+        yield screen
+    finally:
+        try:
+            if screen.exists:
+                screen.quit()
+        except Exception:
+            pass
+
+
+def _wait_for(predicate, timeout=3.0, interval=0.05):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        value = predicate()
+        if value:
+            return value
+        time.sleep(interval)
+    return predicate()
+
+
+def test_screen_lifecycle_against_real_gnu_screen(screen_session):
+    assert screen_session.exists is True
+    assert any(screen.name == screen_session.name for screen in list_screens())
+
+    screen_session.quit()
+
+    assert _wait_for(lambda: not screen_session.exists) is True
+
+
+def test_send_text_and_send_line_against_real_gnu_screen(screen_session):
+    typed = "screenutils-integration-ok"
+
+    screen_session.send_text(typed)
+
+    def hardcopy_contains_typed_text():
+        return typed in screen_session.hardcopy()
+
+    assert _wait_for(hardcopy_contains_typed_text, timeout=5.0) is True
+
+    screen_session.send_line("clear")

--- a/tests/test_integration_screen.py
+++ b/tests/test_integration_screen.py
@@ -1,10 +1,12 @@
 import shutil
 import time
+from subprocess import CalledProcessError
 from uuid import uuid4
 
 import pytest
 
 from screenutils import Screen, list_screens
+from screenutils.errors import ScreenNotFoundError
 
 
 pytestmark = pytest.mark.integration
@@ -27,7 +29,7 @@ def screen_session():
         try:
             if screen.exists:
                 screen.quit()
-        except Exception:
+        except (CalledProcessError, ScreenNotFoundError):
             pass
 
 
@@ -50,7 +52,7 @@ def test_screen_lifecycle_against_real_gnu_screen(screen_session):
     assert _wait_for(lambda: not screen_session.exists) is True
 
 
-def test_send_text_and_send_line_against_real_gnu_screen(screen_session):
+def test_send_text_against_real_gnu_screen(screen_session):
     typed = "screenutils-integration-ok"
 
     screen_session.send_text(typed)
@@ -60,4 +62,13 @@ def test_send_text_and_send_line_against_real_gnu_screen(screen_session):
 
     assert _wait_for(hardcopy_contains_typed_text, timeout=5.0) is True
 
-    screen_session.send_line("clear")
+
+def test_send_line_executes_command_against_real_gnu_screen(screen_session):
+    echoed = f"screenutils-send-line-{uuid4().hex}"
+    encoded_echo = "".join(f"\\{ord(char):03o}" for char in echoed)
+    screen_session.send_line(f"printf '{encoded_echo}\\n'")
+
+    def hardcopy_contains_echoed_text():
+        return echoed in screen_session.hardcopy()
+
+    assert _wait_for(hardcopy_contains_echoed_text, timeout=5.0) is True


### PR DESCRIPTION
## Summary

- add optional pytest integration coverage for real GNU screen lifecycle and text injection
- skip integration tests automatically when GNU screen is unavailable
- register the integration marker in pytest config
- make send_text/send_line use screen's argument form that works against real GNU screen and add hardcopy() for visible-buffer inspection

Closes #13.

## Tests

- .venv/bin/python -m pytest -q