### PR TITLE
fix: harden tailf rotation and timeout handling

### DIFF
--- a/screenutils/screen.py
+++ b/screenutils/screen.py
@@ -6,6 +6,7 @@
 # Please ask if you wish a more permissive license.
 
 from dataclasses import dataclass
+from os import fstat
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from subprocess import PIPE, STDOUT, CalledProcessError, CompletedProcess, run
@@ -97,22 +98,62 @@ def tailf(
     ``FileNotFoundError``.
     """
     path = Path(file_)
-    last_size = 0 if missing_ok and not path.exists() else path.stat().st_size
+    last_position = 0
+    last_identity = None
+    initialized = False
     while True:
-        if not path.exists():
+        try:
+            stat = path.stat()
+        except FileNotFoundError:
             if not missing_ok:
                 raise FileNotFoundError(path)
+            last_position = 0
+            last_identity = None
+            initialized = True
             if interval:
                 sleep(interval)
             yield ""
             continue
 
-        cur_size = path.stat().st_size
-        if cur_size != last_size:
-            with path.open("r", encoding=encoding, errors=errors) as f:
-                f.seek(last_size if cur_size > last_size else 0)
-                text = f.read()
-            last_size = cur_size
+        identity = (stat.st_dev, stat.st_ino)
+        if not initialized:
+            last_position = stat.st_size
+            last_identity = identity
+            initialized = True
+            if interval:
+                sleep(interval)
+            yield ""
+            continue
+
+        should_read_from_start = (
+            identity != last_identity or stat.st_size < last_position
+        )
+        read_from = 0 if should_read_from_start else last_position
+
+        if stat.st_size != last_position or should_read_from_start:
+            try:
+                with path.open("r", encoding=encoding, errors=errors) as f:
+                    opened_stat = fstat(f.fileno())
+                    opened_identity = (opened_stat.st_dev, opened_stat.st_ino)
+                    if (
+                        opened_identity != last_identity
+                        or opened_stat.st_size < last_position
+                    ):
+                        read_from = 0
+                    f.seek(read_from)
+                    text = f.read()
+                    last_position = f.tell()
+            except FileNotFoundError:
+                if not missing_ok:
+                    raise
+                last_position = 0
+                last_identity = None
+                if interval:
+                    sleep(interval)
+                yield ""
+                continue
+
+            last_identity = opened_identity
             yield text
         else:
             if interval:
@@ -214,16 +255,19 @@ class Screen(object):
             raise RuntimeError("Logs are not enabled. Call enable_logs() first.")
 
         deadline = None if timeout is None else monotonic() + timeout
-        for chunk in tailf(
+        logs = tailf(
             self._logfilename,
             interval=interval,
             encoding=encoding,
             errors=errors,
             missing_ok=True,
-        ):
-            if deadline is not None and monotonic() >= deadline:
-                return
-            yield chunk
+        )
+        while True:
+            if deadline is not None:
+                remaining = deadline - monotonic()
+                if remaining <= 0 or (interval and remaining < interval):
+                    return
+            yield next(logs)
 
     def disable_logs(self, remove_logfile: bool = False) -> None:
         self._screen_commands("log off")

--- a/tests/test_tailf.py
+++ b/tests/test_tailf.py
@@ -61,6 +61,61 @@ def test_tailf_can_wait_for_missing_file(monkeypatch, tmp_path):
     assert next(logs) == "created"
 
 
+def test_tailf_reads_recreated_missing_file_from_start(monkeypatch, tmp_path):
+    sleeps = []
+    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: sleeps.append(seconds))
+
+    log_file = tmp_path / "screen.log"
+    log_file.write_text("old content")
+
+    logs = tailf(log_file, interval=0.5, missing_ok=True)
+
+    assert next(logs) == ""
+    sleeps.clear()
+
+    log_file.unlink()
+
+    assert next(logs) == ""
+    assert sleeps == [0.5]
+
+    log_file.write_text("new content is longer than old content")
+
+    assert next(logs) == "new content is longer than old content"
+
+
+def test_tailf_tolerates_missing_file_between_stat_and_open(
+    monkeypatch, tmp_path
+):
+    sleeps = []
+    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: sleeps.append(seconds))
+
+    log_file = tmp_path / "screen.log"
+    log_file.write_text("initial")
+
+    logs = tailf(log_file, interval=0.25, missing_ok=True)
+
+    assert next(logs) == ""
+    sleeps.clear()
+
+    original_open = type(log_file).open
+
+    def unlink_then_open(path, *args, **kwargs):
+        if path == log_file:
+            path.unlink()
+        return original_open(path, *args, **kwargs)
+
+    log_file.write_text("initial\nnext")
+    monkeypatch.setattr(type(log_file), "open", unlink_then_open)
+
+    assert next(logs) == ""
+    assert sleeps == [0.25]
+
+    monkeypatch.setattr(type(log_file), "open", original_open)
+    log_file.write_text("recreated")
+
+    assert next(logs) == "recreated"
+
+
 def test_tailf_replaces_invalid_bytes_when_configured(tmp_path):
     log_file = tmp_path / "screen.log"
     log_file.write_bytes(b"initial")
@@ -114,3 +169,39 @@ def test_tail_logs_stops_after_timeout(monkeypatch, tmp_path):
     assert next(logs) == ""
     with pytest.raises(StopIteration):
         next(logs)
+
+
+def test_tail_logs_timeout_zero_yields_no_chunks(monkeypatch, tmp_path):
+    sleeps = []
+    monkeypatch.setattr("screenutils.screen.monotonic", lambda: 1.0)
+    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: sleeps.append(seconds))
+
+    log_file = tmp_path / "screen.log"
+    log_file.write_text("")
+
+    screen = Screen("job")
+    screen._logfilename = str(log_file)
+
+    with pytest.raises(StopIteration):
+        next(screen.tail_logs(timeout=0, interval=0.5))
+
+    assert sleeps == []
+
+
+def test_tail_logs_short_timeout_does_not_sleep_past_deadline(
+    monkeypatch, tmp_path
+):
+    times = iter([0.0, 0.05])
+    sleeps = []
+    monkeypatch.setattr("screenutils.screen.monotonic", lambda: next(times))
+    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: sleeps.append(seconds))
+
+    log_file = tmp_path / "screen.log"
+    log_file.write_text("")
+
+    screen = Screen("job")
+    screen._logfilename = str(log_file)
+
+    with pytest.raises(StopIteration):
+        next(screen.tail_logs(timeout=0.01, interval=0.5))
+    assert sleeps == []


### PR DESCRIPTION
## Summary

- track tail offsets with file identity and actual read positions
- reset tail state when tolerated missing files disappear and later reappear
- avoid sleeping past short tail_logs timeouts before yielding
- add regression coverage for recreated logs, deletion races, and timeout=0 / timeout < interval

Closes #20.

## Tests

- .venv/bin/python -m pytest tests/test_tailf.py -q
- .venv/bin/python -m pytest -q