### PR TITLE
[codex] rename project to screenctl

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,8 +1,8 @@
 Contributors
 ============
 
-screenutils is a project started and maintained by Christophe Narbonne.
-As I don't use it anymore, you may want to fork it or take the lead.
+screenctl is maintained under the new project name by TutuchanXD.
+It originated from work started by Christophe Narbonne.
 The following people have contributed:
 
 - Alexis Métaireau

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,5 @@
 README.rst
 setup.py
-screenutils/__init__.py
-screenutils/errors.py
-screenutils/screen.py
+screenctl/__init__.py
+screenctl/errors.py
+screenctl/screen.py

--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,9 @@
-CAUTION: this project is not maintained anymore as it's maintainer don't use it anymore
-(and switched to tmux). If you contribute a bit, you may reclaim this project.
+screenctl is maintained as the active project name for this GNU screen helper library.
 
+screenctl
+=========
 
-screenutils
-===========
-
-screenutils is a set of classes that should help handling gnu-screen windows.
+screenctl is a set of classes that should help handling gnu-screen windows.
 
 It requires gnu-screen binary installed (named screen and in your path) to work.
 
@@ -17,7 +15,7 @@ Example usage
 
 Example in a python console::
 
-   >>> from screenutils import list_screens, Screen
+   >>> from screenctl import list_screens, Screen
    >>> list_screens()
    []
    >>> s = Screen("session1",True)
@@ -36,7 +34,7 @@ Example in a python console::
    none                   1512676         0   1512676   0% /lib/init/rw
    none                  20161172   8084052  11052980  43% /var/lib/ureadahead/debugfs
    /dev/sda7            403567768 196284216 186783420  52% /home
-   popi@popi-laptop:~/Dev/github/screenutils$
+   popi@popi-laptop:~/Dev/github/screenctl$
    >>> s.disable_logs()
    >>> s = None
    >>> s = Screen("session1")
@@ -56,13 +54,13 @@ Example in a python console::
 Installation
 -------------
 
-You could install screenutils from github, by doing the following::
+You could install screenctl from github, by doing the following::
 
-    $ python -m pip install git+http://github.com/Christophe31/screenutils.git
+    $ python -m pip install git+https://github.com/TutuchanXD/screenctl.git
 
 Or by just using the packages published on Pypi, for instance with pip::
 
-    $ python -m pip install screenutils
+    $ python -m pip install screenctl
 
 Features
 ---------

--- a/docs/modernization-plan.md
+++ b/docs/modernization-plan.md
@@ -1,10 +1,10 @@
-# screenutils Modernization Plan
+# screenctl Modernization Plan
 
-This document describes a staged modernization plan for `screenutils`, a small Python wrapper around GNU screen. The goal is to make the project safe, testable, Python 3 native, and suitable for automation use cases while preserving the spirit of the original API where practical.
+This document describes a staged modernization plan for `screenctl`, a small Python wrapper around GNU screen. The goal is to make the project safe, testable, Python 3 native, and suitable for automation use cases while preserving the spirit of the original API where practical.
 
 ## 1. Project Assessment
 
-`screenutils` currently provides a thin Python interface for:
+`screenctl` currently provides a thin Python interface for:
 
 - Listing GNU screen sessions.
 - Creating named screen sessions.
@@ -85,7 +85,7 @@ Acceptance criteria:
 - The existing public imports still work:
 
   ```python
-  from screenutils import Screen, list_screens, ScreenNotFoundError
+  from screenctl import Screen, list_screens, ScreenNotFoundError
   ```
 
 - CI runs successfully.
@@ -299,7 +299,7 @@ Improve developer ergonomics while preserving the original API where possible.
 Possible new API surface:
 
 ```python
-from screenutils import Screen
+from screenctl import Screen
 
 s = Screen.ensure("job")
 s.send_line("python train.py")
@@ -489,7 +489,7 @@ Recommended safeguards:
 Before starting implementation, decide:
 
 1. What minimum Python version should be supported?
-2. Should this fork keep the package name `screenutils`, or use a new name if republished?
+2. Future publication should use the `screenctl` package and repository name.
 3. Should `Screen.kill()` remain the preferred method, or should `quit()` become primary?
 4. Should multi-user ACL support remain, given the system-level permission implications?
 5. Should the project maintain GPLv2+ licensing, or only clarify the existing license file?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "screenutils"
+name = "screenctl"
 version = "0.0.1.6.2"
 description = "Library for GNU screen: create, close, list, log sessions, and inject commands."
 readme = "README.rst"
@@ -27,15 +27,15 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/TutuchanXD/screenutils"
-Repository = "https://github.com/TutuchanXD/screenutils"
-"Upstream Repository" = "https://github.com/Christophe31/screenutils"
+Homepage = "https://github.com/TutuchanXD/screenctl"
+Repository = "https://github.com/TutuchanXD/screenctl"
 
 [tool.setuptools.packages.find]
-include = ["screenutils*"]
+include = ["screenctl*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 markers = [
     "integration: tests that require a real GNU screen binary",
 ]

--- a/screenctl/__init__.py
+++ b/screenctl/__init__.py
@@ -1,0 +1,6 @@
+from screenctl.errors import ScreenNotFoundError
+from screenctl.screen import list_screens, Screen
+
+__all__ = ("list_screens",
+           "Screen",
+           "ScreenNotFoundError")

--- a/screenctl/errors.py
+++ b/screenctl/errors.py
@@ -1,4 +1,4 @@
-"""Errors for the screenutils module"""
+"""Errors for the screenctl module"""
 
 class ScreenNotFoundError(Exception):
     """raised when the screen does not exists"""

--- a/screenctl/screen.py
+++ b/screenctl/screen.py
@@ -12,7 +12,7 @@ from subprocess import PIPE, STDOUT, CalledProcessError, CompletedProcess, run
 from time import monotonic, sleep
 from typing import Generator, List, Optional, Union
 
-from screenutils.errors import ScreenNotFoundError
+from screenctl.errors import ScreenNotFoundError
 
 
 @dataclass(frozen=True)

--- a/screenutils/__init__.py
+++ b/screenutils/__init__.py
@@ -1,6 +1,0 @@
-from screenutils.errors import ScreenNotFoundError
-from screenutils.screen import list_screens, Screen
-
-__all__ = ("list_screens",
-           "Screen",
-           "ScreenNotFoundError")

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
 setup(
-    name='screenutils',
+    name='screenctl',
 )
 

--- a/tests/test_high_level_api.py
+++ b/tests/test_high_level_api.py
@@ -1,7 +1,7 @@
 import pytest
 
-from screenutils import Screen
-from screenutils.errors import ScreenNotFoundError
+from screenctl import Screen
+from screenctl.errors import ScreenNotFoundError
 
 
 SCREEN_LS = """There is a screen on:
@@ -15,8 +15,8 @@ NO_SCREENS = """No Sockets found in /run/screen/S-user.
 
 def test_create_initializes_and_returns_screen(monkeypatch):
     calls = []
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: NO_SCREENS)
-    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: NO_SCREENS)
+    monkeypatch.setattr("screenctl.screen._run_screen", lambda *args: calls.append(args))
 
     screen = Screen.create("job")
 
@@ -27,8 +27,8 @@ def test_create_initializes_and_returns_screen(monkeypatch):
 
 def test_ensure_is_create_alias(monkeypatch):
     calls = []
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: NO_SCREENS)
-    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: NO_SCREENS)
+    monkeypatch.setattr("screenctl.screen._run_screen", lambda *args: calls.append(args))
 
     screen = Screen.ensure("job")
 
@@ -37,7 +37,7 @@ def test_ensure_is_create_alias(monkeypatch):
 
 
 def test_get_returns_existing_screen(monkeypatch):
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: SCREEN_LS)
 
     screen = Screen.get("job")
 
@@ -46,7 +46,7 @@ def test_get_returns_existing_screen(monkeypatch):
 
 
 def test_get_raises_for_missing_screen(monkeypatch):
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: NO_SCREENS)
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: NO_SCREENS)
 
     with pytest.raises(ScreenNotFoundError):
         Screen.get("job")
@@ -55,9 +55,9 @@ def test_get_raises_for_missing_screen(monkeypatch):
 def test_send_text_sends_without_enter(monkeypatch):
     calls = []
     sleeps = []
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
-    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
-    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenctl.screen._run_screen", lambda *args: calls.append(args))
+    monkeypatch.setattr("screenctl.screen.sleep", lambda seconds: sleeps.append(seconds))
 
     Screen("job").send_text("hello")
 
@@ -68,9 +68,9 @@ def test_send_text_sends_without_enter(monkeypatch):
 def test_send_line_sends_text_and_enter(monkeypatch):
     calls = []
     sleeps = []
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
-    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
-    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenctl.screen._run_screen", lambda *args: calls.append(args))
+    monkeypatch.setattr("screenctl.screen.sleep", lambda seconds: sleeps.append(seconds))
 
     Screen("job").send_line("echo hello")
 
@@ -81,9 +81,9 @@ def test_send_line_sends_text_and_enter(monkeypatch):
 def test_legacy_send_commands_delegates_to_send_line(monkeypatch):
     calls = []
     sleeps = []
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
-    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
-    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenctl.screen._run_screen", lambda *args: calls.append(args))
+    monkeypatch.setattr("screenctl.screen.sleep", lambda seconds: sleeps.append(seconds))
 
     Screen("job").send_commands("one", "two")
 
@@ -111,9 +111,9 @@ def test_hardcopy_uses_screen_runner_and_returns_file_text(monkeypatch, tmp_path
         calls.append(args)
         hardcopy_path.write_text("visible text", encoding="utf-8")
 
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
-    monkeypatch.setattr("screenutils.screen.NamedTemporaryFile", FakeTemporaryFile)
-    monkeypatch.setattr("screenutils.screen._run_screen", fake_run_screen)
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenctl.screen.NamedTemporaryFile", FakeTemporaryFile)
+    monkeypatch.setattr("screenctl.screen._run_screen", fake_run_screen)
 
     assert Screen("job").hardcopy() == "visible text"
     assert calls == [("-S", "1234", "-X", "hardcopy", "-h", str(hardcopy_path))]
@@ -121,9 +121,9 @@ def test_hardcopy_uses_screen_runner_and_returns_file_text(monkeypatch, tmp_path
 
 def test_ctrl_c_and_quit_aliases(monkeypatch):
     calls = []
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
-    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
-    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: None)
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenctl.screen._run_screen", lambda *args: calls.append(args))
+    monkeypatch.setattr("screenctl.screen.sleep", lambda seconds: None)
 
     screen = Screen("job")
     screen.ctrl_c()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,4 +1,4 @@
-from screenutils import Screen, ScreenNotFoundError, list_screens
+from screenctl import Screen, ScreenNotFoundError, list_screens
 
 
 def test_public_imports_are_available():

--- a/tests/test_integration_screen.py
+++ b/tests/test_integration_screen.py
@@ -5,8 +5,8 @@ from uuid import uuid4
 
 import pytest
 
-from screenutils import Screen, list_screens
-from screenutils.errors import ScreenNotFoundError
+from screenctl import Screen, list_screens
+from screenctl.errors import ScreenNotFoundError
 
 
 pytestmark = pytest.mark.integration
@@ -21,7 +21,7 @@ def screen_session():
     if not _screen_available():
         pytest.skip("GNU screen binary is not installed")
 
-    name = f"screenutils-it-{uuid4().hex}"
+    name = f"screenctl-it-{uuid4().hex}"
     screen = Screen.create(name)
     try:
         yield screen
@@ -53,7 +53,7 @@ def test_screen_lifecycle_against_real_gnu_screen(screen_session):
 
 
 def test_send_text_against_real_gnu_screen(screen_session):
-    typed = "screenutils-integration-ok"
+    typed = "screenctl-integration-ok"
 
     screen_session.send_text(typed)
 
@@ -64,7 +64,7 @@ def test_send_text_against_real_gnu_screen(screen_session):
 
 
 def test_send_line_executes_command_against_real_gnu_screen(screen_session):
-    echoed = f"screenutils-send-line-{uuid4().hex}"
+    echoed = f"screenctl-send-line-{uuid4().hex}"
     encoded_echo = "".join(f"\\{ord(char):03o}" for char in echoed)
     screen_session.send_line(f"printf '{encoded_echo}\\n'")
 

--- a/tests/test_screen_commands.py
+++ b/tests/test_screen_commands.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from screenutils.screen import Screen, _run_screen, _screen_output
+from screenctl.screen import Screen, _run_screen, _screen_output
 
 
 SCREEN_LS = """There is a screen on:
@@ -14,7 +14,7 @@ SCREEN_LS = """There is a screen on:
 
 def test_run_screen_uses_argument_list_without_shell(monkeypatch):
     run_mock = Mock()
-    monkeypatch.setattr("screenutils.screen.run", run_mock)
+    monkeypatch.setattr("screenctl.screen.run", run_mock)
 
     _run_screen("-d", "1234")
 
@@ -29,15 +29,15 @@ def test_screen_output_returns_output_from_non_zero_screen_command(monkeypatch):
     def fake_run(*args, **kwargs):
         raise CalledProcessError(1, args[0], output="No Sockets found.\n")
 
-    monkeypatch.setattr("screenutils.screen.run", fake_run)
+    monkeypatch.setattr("screenctl.screen.run", fake_run)
 
     assert _screen_output("-ls") == "No Sockets found.\n"
 
 
 def test_initialize_creates_detached_session_without_tty(monkeypatch):
     calls = []
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: "No Sockets found.\n")
-    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: "No Sockets found.\n")
+    monkeypatch.setattr("screenctl.screen._run_screen", lambda *args: calls.append(args))
 
     Screen("job; rm -rf /", initialize=True)
 
@@ -46,8 +46,8 @@ def test_initialize_creates_detached_session_without_tty(monkeypatch):
 
 def test_initialize_does_not_create_existing_session(monkeypatch):
     calls = []
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
-    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenctl.screen._run_screen", lambda *args: calls.append(args))
 
     Screen("job", initialize=True)
 
@@ -56,8 +56,8 @@ def test_initialize_does_not_create_existing_session(monkeypatch):
 
 def test_detach_runs_screen_d_with_cached_screen_id(monkeypatch):
     calls = []
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
-    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenctl.screen._run_screen", lambda *args: calls.append(args))
 
     Screen("job").detach()
 
@@ -66,9 +66,9 @@ def test_detach_runs_screen_d_with_cached_screen_id(monkeypatch):
 
 def test_screen_commands_run_through_argument_list(monkeypatch):
     calls = []
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
-    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: calls.append(args))
-    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: None)
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenctl.screen._run_screen", lambda *args: calls.append(args))
+    monkeypatch.setattr("screenctl.screen.sleep", lambda seconds: None)
 
     Screen("job")._screen_commands("quit")
 
@@ -79,9 +79,9 @@ def test_disable_logs_removes_log_file_with_pathlib(monkeypatch, tmp_path):
     log_file = tmp_path / "screen.log"
     log_file.write_text("hello")
 
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
-    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: None)
-    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: None)
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenctl.screen._run_screen", lambda *args: None)
+    monkeypatch.setattr("screenctl.screen.sleep", lambda seconds: None)
 
     screen = Screen("job")
     screen._logfilename = str(log_file)
@@ -94,9 +94,9 @@ def test_disable_logs_does_not_remove_log_file_by_default(monkeypatch, tmp_path)
     log_file = tmp_path / "screen.log"
     log_file.write_text("hello")
 
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
-    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: None)
-    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: None)
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenctl.screen._run_screen", lambda *args: None)
+    monkeypatch.setattr("screenctl.screen.sleep", lambda seconds: None)
 
     screen = Screen("job")
     screen._logfilename = str(log_file)

--- a/tests/test_screen_parsing.py
+++ b/tests/test_screen_parsing.py
@@ -1,7 +1,7 @@
 import pytest
 
-from screenutils.errors import ScreenNotFoundError
-from screenutils.screen import Screen, ScreenInfo, list_screens, parse_screen_ls
+from screenctl.errors import ScreenNotFoundError
+from screenctl.screen import Screen, ScreenInfo, list_screens, parse_screen_ls
 
 
 NO_SCREENS = """No Sockets found in /run/screen/S-user.
@@ -66,7 +66,7 @@ def test_parse_screen_ls_ignores_irrelevant_lines():
 
 
 def test_list_screens_uses_parsed_session_names(monkeypatch):
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: MULTIPLE_SCREENS)
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: MULTIPLE_SCREENS)
 
     screens = list_screens()
 
@@ -75,7 +75,7 @@ def test_list_screens_uses_parsed_session_names(monkeypatch):
 
 
 def test_screen_exists_uses_exact_session_name_matching(monkeypatch):
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: MULTIPLE_SCREENS)
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: MULTIPLE_SCREENS)
 
     assert Screen("foo").exists is True
     assert Screen("foo.bar").exists is True
@@ -84,7 +84,7 @@ def test_screen_exists_uses_exact_session_name_matching(monkeypatch):
 
 
 def test_screen_info_properties_use_exact_session_name_matching(monkeypatch):
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: MULTIPLE_SCREENS)
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: MULTIPLE_SCREENS)
 
     screen = Screen("foo.bar")
 
@@ -93,7 +93,7 @@ def test_screen_info_properties_use_exact_session_name_matching(monkeypatch):
 
 
 def test_screen_info_properties_raise_for_missing_session(monkeypatch):
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: MULTIPLE_SCREENS)
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: MULTIPLE_SCREENS)
 
     with pytest.raises(ScreenNotFoundError):
         Screen("missing").id

--- a/tests/test_tailf.py
+++ b/tests/test_tailf.py
@@ -1,6 +1,6 @@
 import pytest
 
-from screenutils.screen import Screen, tailf
+from screenctl.screen import Screen, tailf
 
 
 SCREEN_LS = """There is a screen on:
@@ -11,7 +11,7 @@ SCREEN_LS = """There is a screen on:
 
 def test_tailf_yields_appended_text_without_busy_wait(monkeypatch, tmp_path):
     sleeps = []
-    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr("screenctl.screen.sleep", lambda seconds: sleeps.append(seconds))
 
     log_file = tmp_path / "screen.log"
     log_file.write_text("initial")
@@ -48,7 +48,7 @@ def test_tailf_missing_initial_file_raises_by_default(tmp_path):
 
 def test_tailf_can_wait_for_missing_file(monkeypatch, tmp_path):
     sleeps = []
-    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr("screenctl.screen.sleep", lambda seconds: sleeps.append(seconds))
 
     log_file = tmp_path / "missing.log"
     logs = tailf(log_file, interval=0.5, missing_ok=True)
@@ -84,9 +84,9 @@ def test_tail_logs_requires_logs_to_be_enabled():
 def test_enable_logs_configures_tail_logs(monkeypatch, tmp_path):
     log_file = tmp_path / "screen.log"
 
-    monkeypatch.setattr("screenutils.screen._screen_output", lambda *args: SCREEN_LS)
-    monkeypatch.setattr("screenutils.screen._run_screen", lambda *args: None)
-    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: None)
+    monkeypatch.setattr("screenctl.screen._screen_output", lambda *args: SCREEN_LS)
+    monkeypatch.setattr("screenctl.screen._run_screen", lambda *args: None)
+    monkeypatch.setattr("screenctl.screen.sleep", lambda seconds: None)
 
     screen = Screen("job")
     screen.enable_logs(str(log_file), interval=0)
@@ -100,8 +100,8 @@ def test_enable_logs_configures_tail_logs(monkeypatch, tmp_path):
 
 def test_tail_logs_stops_after_timeout(monkeypatch, tmp_path):
     times = iter([0.0, 0.05, 0.2])
-    monkeypatch.setattr("screenutils.screen.monotonic", lambda: next(times))
-    monkeypatch.setattr("screenutils.screen.sleep", lambda seconds: None)
+    monkeypatch.setattr("screenctl.screen.monotonic", lambda: next(times))
+    monkeypatch.setattr("screenctl.screen.sleep", lambda seconds: None)
 
     log_file = tmp_path / "screen.log"
     log_file.write_text("")


### PR DESCRIPTION
## Summary
- Rename the Python distribution, source package, imports, tests, and docs from `screenutils` to `screenctl`.
- Update project URLs and README installation examples to `TutuchanXD/screenctl`.
- Add pytest `pythonpath = ["."]` so `pytest` resolves the renamed local package consistently.

## Validation
- `pytest -q`
- `python -m pip install --no-deps --dry-run -e .`